### PR TITLE
Tops 3212 delwaterman fix up provider

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -356,6 +356,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190221075227-b4e8571b14e0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 h1:vsphBvatvfbhlb4PO1BYSr9dzugGxJ/SQHoNufZJq1w=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/redshift/data_source_redshift_schema.go
+++ b/redshift/data_source_redshift_schema.go
@@ -7,11 +7,6 @@ import (
 	"github.com/hashicorp/terraform/helper/schema"
 )
 
-/*
-TODO
-Add database property. This will require a new connection since you can't have databse agnostic connections in redshift/postgres
-*/
-
 func dataSourceRedshiftSchema() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceRedshiftSchemaReadByName,

--- a/redshift/data_source_redshift_schema.go
+++ b/redshift/data_source_redshift_schema.go
@@ -31,7 +31,7 @@ func dataSourceRedshiftSchemaReadByName(d *schema.ResourceData, meta interface{}
 		owner int
 	)
 
-	name := d.Get("name").(string)
+	name := d.Get("schema_name").(string)
 	redshiftClient := meta.(*Client).db
 
 	err := redshiftClient.QueryRow("select oid, nspowner from pg_namespace where nspname = $1", name).Scan(&oid, &owner)

--- a/redshift/data_source_redshift_schema.go
+++ b/redshift/data_source_redshift_schema.go
@@ -1,0 +1,53 @@
+package redshift
+
+import (
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+/*
+TODO
+Add database property. This will require a new connection since you can't have databse agnostic connections in redshift/postgres
+*/
+
+func dataSourceRedshiftSchema() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceRedshiftSchemaReadByName,
+
+		Schema: map[string]*schema.Schema{
+			"schema_name": {
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"owner": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceRedshiftSchemaReadByName(d *schema.ResourceData, meta interface{}) error {
+	var (
+		oid   int
+		owner int
+	)
+
+	name := d.Get("name").(string)
+	redshiftClient := meta.(*Client).db
+
+	err := redshiftClient.QueryRow("select oid, nspowner from pg_namespace where nspname = $1", name).Scan(&oid, &owner)
+
+	if err != nil {
+		log.Print(err)
+		return err
+	}
+
+	d.SetId(strconv.Itoa(oid))
+	d.Set("owner", owner)
+
+	return err
+}

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -25,6 +25,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Description: "master password",
 				Required:    true,
+				Sensitive:   true,
 			},
 			"port": {
 				Type:        schema.TypeString,

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -2,9 +2,10 @@ package redshift
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"log"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -24,6 +25,7 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Description: "master password",
 				Required:    true,
+				Sensitive:   true,
 			},
 			"port": {
 				Type:        schema.TypeString,

--- a/redshift/provider.go
+++ b/redshift/provider.go
@@ -2,9 +2,10 @@ package redshift
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
-	"log"
 )
 
 func Provider() terraform.ResourceProvider {
@@ -50,6 +51,9 @@ func Provider() terraform.ResourceProvider {
 			"redshift_database":               redshiftDatabase(),
 			"redshift_schema":                 redshiftSchema(),
 			"redshift_group_schema_privilege": redshiftSchemaGroupPrivilege(),
+		},
+		DataSourcesMap: map[string]*schema.Resource{
+			"redshift_schema": dataSourceRedshiftSchema(),
 		},
 		ConfigureFunc: providerConfigure,
 	}

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -3,10 +3,11 @@ package redshift
 import (
 	"database/sql"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/schema"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/hashicorp/terraform/helper/schema"
 )
 
 func redshiftUser() *schema.Resource {
@@ -26,8 +27,9 @@ func redshiftUser() *schema.Resource {
 				Required: true,
 			},
 			"password": { //Can we read this back from the db? If not hwo can we tell if its changed? Do we need to use md5hash?
-				Type:     schema.TypeString,
-				Optional: true,
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
 			},
 			"valid_until": {
 				Type:     schema.TypeString,

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -26,7 +26,7 @@ func redshiftUser() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
-			"password": { //Can we read this back from the db? If not hwo can we tell if its changed? Do we need to use md5hash?
+			"password": { //Can we read this back from the db? If not how can we tell if its changed? Do we need to use md5hash?
 				Type:      schema.TypeString,
 				Optional:  true,
 				Sensitive: true,


### PR DESCRIPTION
https://greenhouseio.atlassian.net/browse/TOPS-3212

This PR brings together multiple fixes onto the `gh-master` branch. The `gh-master` branch is Greenhouse's master forked version, that allows us to maintain a version of the provider specific to Greenhouse but also allow us to pull in fixes from the master branch. 

Some of these fixes have been submitted to the original repository as PRs, but we don't want to wait for them to be approved. See:

https://github.com/frankfarrell/terraform-provider-redshift/pull/39
https://github.com/frankfarrell/terraform-provider-redshift/pull/38

Fixes in this PR:
- Add data source `redshift_schema` to allow us to more easily manage schemas in datacoral and manage permissions in terraform
- Set password fields as sensitive
- Change SQL for destroying groups to not scan `pg_temp` schemas when revoking permissions
- Add Makefile commands for uploading plugins to Greenhouse's terraform plugin S3 bucket

![](https://media.giphy.com/media/J8rTOn3pwuYog/giphy.gif)