### PR TITLE
narrowing the namespace scope for revoking privileges

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -60,7 +60,7 @@ install-local-plugin: build-dist
 	mkdir -p $(HOME)/.terraform.d/plugin-cache
 	cp dist/$(PLATFORM)/$(ARCH)/$(BIN_NAME) $(HOME)/.terraform.d/plugins/tf-registry.greenhouse.dev/grnhse/redshift/$(VERSION)/$(PLATFORM)_$(ARCH)/$(BIN_NAME)
 
-clear-local-plugins:
+clear-local-plugin:
 	rm -rf $(HOME)/.terraform.d/plugins/tf-registry.greenhouse.dev/grnhse/redshift
 
 .PHONY: build test testacc vet fmt fmtcheck errcheck test-compile install-local-plugin clear-local-plugin

--- a/redshift/resource_redshift_schema_group_privilege.go
+++ b/redshift/resource_redshift_schema_group_privilege.go
@@ -119,7 +119,7 @@ func resourceRedshiftSchemaGroupPrivilegeCreate(d *schema.ResourceData, meta int
 	grants := validateGrants(d)
 	schemaGrants := validateSchemaGrants(d)
 
-	if len(grants) == 0 && len(schemaGrants) == 0  {
+	if len(grants) == 0 && len(schemaGrants) == 0 {
 		tx.Rollback()
 		return NewError("Must have at least 1 privilege")
 	}
@@ -203,8 +203,8 @@ func resourceRedshiftSchemaGroupPrivilegeRead(d *schema.ResourceData, meta inter
 
 func readRedshiftSchemaGroupPrivilege(d *schema.ResourceData, tx *sql.Tx) error {
 	var (
-		usagePrivilege		bool
-		createPrivilege		bool
+		usagePrivilege      bool
+		createPrivilege     bool
 		selectPrivilege     bool
 		updatePrivilege     bool
 		insertPrivilege     bool
@@ -276,7 +276,7 @@ func resourceRedshiftSchemaGroupPrivilegeUpdate(d *schema.ResourceData, meta int
 	grants := validateGrants(d)
 	schemaGrants := validateSchemaGrants(d)
 
-	if len(grants) == 0 && len(schemaGrants) == 0  {
+	if len(grants) == 0 && len(schemaGrants) == 0 {
 		tx.Rollback()
 		return NewError("Must have at least 1 privilege")
 	}

--- a/redshift/resource_redshift_user.go
+++ b/redshift/resource_redshift_user.go
@@ -425,7 +425,7 @@ func resourceRedshiftUserDelete(d *schema.ResourceData, meta interface{}) error 
 	}
 
 	//We need to drop all privileges and default privileges
-	rows, schemasError := redshiftClient.Query("select nspname from pg_namespace")
+	rows, schemasError := redshiftClient.Query("select nspname from pg_namespace where nspowner != 1")
 	defer rows.Close()
 	if schemasError != nil {
 		return schemasError


### PR DESCRIPTION
The provider removes privileges in temp namespaces managed by the `rdsdb` user. This adds 500+ schemas to the revoke privileges step of the delete user action in Terraform, and from what I have found the users we are creating do not contain any privileges in these namespaces anyways. 